### PR TITLE
[issue-17]  Added storage of the step error

### DIFF
--- a/djenga/celery/results.py
+++ b/djenga/celery/results.py
@@ -1,3 +1,4 @@
+from typing import List, Dict
 from celery.result import AsyncResult
 
 
@@ -12,6 +13,17 @@ class AsyncDetailedResult(AsyncResult):
                  app=None, parent=None):
         super().__init__(id, backend, task_name, app, parent)
 
-    def details(self):
+    def details(self) -> List[Dict]:
+        """
+        Returns a list of dictionaries with the following keys:
+          `key`
+          `description`
+          `details`
+          `latest`
+          `time`
+          `done`
+          `error`
+        :return:
+        """
         meta = self._get_task_meta()
         return meta.get('details') if meta else []

--- a/djenga/celery/tasks.py
+++ b/djenga/celery/tasks.py
@@ -43,6 +43,7 @@ class TaskDetail:
             'details': self.detail,
             'latest': self.detail[-1] if self.detail else None,
             'time': self.millis,
+            'error': self.error,
             'done': self.done,
         }
 

--- a/djenga/core/bunch.py
+++ b/djenga/core/bunch.py
@@ -6,3 +6,6 @@ __all__ = [ 'Bunch' ]
 class Bunch(object):
     def __init__(self, **kwds):
         self.__dict__.update(kwds)
+
+    def json(self):
+        pass

--- a/docs/detail_tasks.md
+++ b/docs/detail_tasks.md
@@ -1,4 +1,4 @@
-# detail tasks
+# detail tasks (aka yakkety tasks)
 
 One of the problems that we've encountered with celery is
 that we want to provide the user a lot more information 
@@ -8,12 +8,12 @@ what is going on in the background.  For customers, this
 is extremely helpful because it indicates that their request
 is being processed.  For your internal agents / business users,
 this is a vital tool to assist in debugging.  To that end,
-we've "extended" (ed., wasn't it really hacked into) celery
+we've "extended" (ed., wasn't it really hacked into?) celery
 to provide a `Task` base class that allows you to provide 
-much more detail to the user as a task is executing.  That
-said, hooking all the pieces together to get this working 
-can be a bit overwhelming.  You'll be using the 
-following classes and functions for all of this to work:
+much more detail to the user as a task is executing.  Hooking 
+all the pieces together to get this working  can be a bit 
+overwhelming.  You'll be using the following classes and 
+functions for all of this to work:
 
 * **`djenga.celery.tasks.DetailTask`**: Base `Task` class 
   that provides helper functions for adding detailed 


### PR DESCRIPTION
## Problem?

A yakkety result user cannot tell if a particular step succeeded or failed.

## Solution!

Add an error field that can be populated with an error
message.  If this field is filled out, it indicates
an error occurred in that step.