### PR TITLE
[issue-20]  promoted logging filters into djenga for cross-project use

### DIFF
--- a/djenga/logging/__init__.py
+++ b/djenga/logging/__init__.py
@@ -1,0 +1,1 @@
+from .filters import *  # noqa

--- a/djenga/logging/filters.py
+++ b/djenga/logging/filters.py
@@ -1,0 +1,23 @@
+import logging
+
+
+__all__  = [
+    'ZeepHttpsFilter',
+    'CeleryRestoringFilter',
+]
+
+
+class ZeepHttpsFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        result: bool = record.name.startswith('zeep.wsdl.bindings')
+        result &= record.levelno == logging.WARNING
+        result &= record.msg.startswith('Forcing soap:address location')
+        return not result
+
+
+class CeleryRestoringFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        result = record.name.startswith('celery.redirected')
+        result &= record.msg.startswith('Restoring')
+        result &= record.msg.endswith('unacknowledged message(s)')
+        return not result

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     bdist_wheel = None
 
-version = '0.8.1'
+version = '0.8.2'
 
 setup(name='djenga',
       version=version,


### PR DESCRIPTION
## Problem?

We will need our logging filters for popular third party
libraries across our stacks.

## Solution!

Add them to the common djenga.